### PR TITLE
Allow any child node type

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ const ReactJSDOM = {
 			global[prop] = origGlobals[prop];
 		});
 
-		return container.children[0];
+		return container.childNodes[0];
 	}
 
 };

--- a/test/react-jsdom.js
+++ b/test/react-jsdom.js
@@ -35,6 +35,26 @@ test('ReactJSDOM renders a React Component', t => {
 	t.is(elem.textContent, 'hi');
 });
 
+test('ReactJSDOM renders a React Fragment', t => {
+	const elem = ReactJSDOM.render((
+		<React.Fragment><TestComponent/></React.Fragment>
+	));
+	t.is(elem.nodeName, 'DIV');
+	t.is(elem.textContent, 'hi');
+});
+
+test('ReactJSDOM renders a Text String', t => {
+	const elem = ReactJSDOM.render('Hello world');
+	t.is(elem.nodeName, '#text');
+	t.is(elem.textContent, 'Hello world');
+});
+
+test('ReactJSDOM renders a Fragment wrapping a text string', t => {
+	const elem = ReactJSDOM.render(<React.Fragment>Hello world</React.Fragment>);
+	t.is(elem.nodeName, '#text');
+	t.is(elem.textContent, 'Hello world');
+});
+
 test('ReactJSDOM allows window instance to be passed in', t => {
 	const window = new Window();
 	const elem = ReactJSDOM.render(<TestComponent/>, window);


### PR DESCRIPTION
Hi @lukechilds, thanks for this library, I'm using it in [react-test](https://www.npmjs.com/package/react-test)! When rendering some plain text, right now it's skipped and dropped even if it's valid:

```js
const result = ReactDOM.render(<>Hello world</>);
console.log(result);  // Nothing
```

With this PR it'll return a [Text Node](https://developer.mozilla.org/en-US/docs/Web/API/Text) if it's a string instead of dropping it:

```js
const result = ReactDOM.render(<>Hello world</>);
console.log(result.textContent);  // 'Hello world'
```

Proposed this to be v3.1.0. I can also bundle in this PR here a solution to #9 and propose a release of a v4.0.0 instead.