### PR TITLE
Allow for a wider range of React versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "homepage": "https://github.com/lukechilds/react-jsdom",
   "dependencies": {
-    "react-dom": "^16.3.1",
+    "react-dom": "^16.3.1 || ^17.0.0",
     "window": "^4.1.1"
   },
   "devDependencies": {
@@ -49,7 +49,7 @@
     "eslint-config-xo-react": "^0.16.0",
     "eslint-plugin-react": "^7.2.0",
     "nyc": "^11.0.3",
-    "react": "^16.3.1",
+    "react": "^16.3.1 || ^17.0.0",
     "this": "^1.0.2",
     "xo": "^0.20.3"
   }


### PR DESCRIPTION
I am having some trouble with React hooks and react versions and I strongly suspect it's because React-JSDOM installs the older 16.x version while the rest of my code uses the 17.x version:

<img width="375" alt="image" src="https://user-images.githubusercontent.com/2801252/129283571-ebca1933-a01a-4188-9ffb-19e3bbdf50f6.png">

So I updated the range of versions, installed it locally and with React 17 it seems to still pass the tests so I think it's good to go!

<img width="1251" alt="Screen Shot 2021-08-13 at 1 46 00" src="https://user-images.githubusercontent.com/2801252/129283901-89558ef4-c6ce-4e0b-8c68-04899acf3ebc.png">

